### PR TITLE
added option to include only dist files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,21 @@
 var fs = require('fs');
 
-module.exports = function(devDependencies, packageJsonFilePath) {
+module.exports = function(devDependencies, packageJsonFilePath, opts) {
   var buffer, packages, keys;
-  
+
+  opts = opts || {};
+
   buffer = fs.readFileSync(packageJsonFilePath || './package.json');
   packages = JSON.parse(buffer.toString());
   keys = [];
-  
+
   for (key in packages.dependencies) {
-    keys.push('./node_modules/' + key + '/**/*');
+    if (opts.includeDist) {
+      var package = JSON.parse(fs.readFileSync('./node_modules/' + key + '/package.json'));
+      keys.push('./node_modules/' + key + '/' + package.main);
+    } else {
+      keys.push('./node_modules/' + key + '/**/*');
+    }
   }
 
   if (devDependencies) {


### PR DESCRIPTION
Option to include only files from ```package.json[main]```

``gnf()``` now expects three arguments: devDependencies: string, packageJsonFilePath: string, and opts: object.

Example opts:
```
{
  includeDist: true
}
```